### PR TITLE
Added documentation for the IoniqEVMonitor

### DIFF
--- a/docs/monitors/HyundaiIoniqEV28.md
+++ b/docs/monitors/HyundaiIoniqEV28.md
@@ -1,1 +1,42 @@
 # Hyundai Ioniq EV (28Kwh)
+
+Reads data from the OBDII Bluetooth Dongle.
+
+## Configuration
+
+`class`: Class name implementing the monitor.
+
+`"class": "iotconnect.monitors.ioniqev.IoniqEVMonitor"`
+
+`port`: The UNIX device file of the adapter.
+
+`"port": "/dev/rfcomm0"`
+
+`baudrate`: The baudrate to use for the connection e.g. 9600, 19200, 38400, ...
+
+`"baudrate": 9600`
+
+`fast`: Set to "True" to optimize the commands sent to the adapter.
+
+`"fast": "False"`
+
+`timeout`: The connection timeout in seconds.
+
+`"timeout": 30`
+
+`interval`: The interval in seconds to read new data.
+
+`"interval": 30`
+
+Sample config:
+
+```
+{
+  "class": "iotconnect.monitors.ioniqev.IoniqEVMonitor",
+  "port": "/dev/rfcomm0",
+  "baudrate": 9600,
+  "fast": "False",
+  "timeout": 30,
+  "interval": 10
+ }
+```

--- a/docs/publishers/MQTTPublisher.md
+++ b/docs/publishers/MQTTPublisher.md
@@ -14,7 +14,7 @@ It publishes the monitored data to an MQTT broker.
 
 ```"broker": "test.mosquitto.org"```
 
-```port```: MQTT broker port.
+```port```: MQTT broker port for TLS.
 
 ```"port": 8883```
 
@@ -28,11 +28,11 @@ It publishes the monitored data to an MQTT broker.
 
 ```topic_prefix```: Topic prefix that will be used to publish information.
 
-```qos```: QOS to be used when publishing to MQTT. Default 0.
+```qos```: Quality of service to be used when publishing to MQTT. Default 0 (at most once message delivery).
 
-```retain```: Retain flag to be used when publishing to MQTT. Default True.
+```retain```: Retain flag to be used when publishing to MQTT. Default True (retain the last message per topic).
 
-Note that ```context``` provided to the publish method will be appended to this topic. So if the ```topic_prefix``` is ```car/sensor/my-car/``` and the context is ```state``` the topic where the data will be published will be: ```car/sensor/my-car/state```.
+Note that the  ```context``` provided to the publish method will be appended to this topic. So if the ```topic_prefix``` is ```car/sensor/my-car/``` and the context is ```state``` the topic where the data will be published will be: ```car/sensor/my-car/state```.
 
 *Note that topic_prefix should end with forward slash ```/```.
 


### PR DESCRIPTION
The documentation for the IoniqEVMonitor was not there yet so I tried to create the documentation for that page. Slightly adjusted the MQTT documentation as well to add a bit more details.

And thank you for creating this project!